### PR TITLE
Add anonymous names in group rankings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,7 +45,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .main {
             padding: 67px 5px 0 255px;
         }
@@ -70,7 +70,7 @@
         z-index: 3;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .titlebar {
             height: 50px;
             line-height: 80px;
@@ -107,7 +107,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .view:after {
             display: none;
         }
@@ -134,7 +134,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menubar {
             border-top-style: none;
             border-top-width: 0;

--- a/src/components/Faq.vue
+++ b/src/components/Faq.vue
@@ -205,7 +205,7 @@
         overflow: visible;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .welcomeAndLogin {
             flex-wrap: nowrap;
         }

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -71,7 +71,7 @@
         display: flex;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .main-menubar {
             background: #f9f9f9;
         }
@@ -91,7 +91,7 @@
         z-index: 3;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menuitem {
             background: #f9f9f9;
             flex: 0 0 auto;
@@ -106,7 +106,7 @@
         background-color: #4baf81;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menuitem:hover {
             background-color: #eee;
         }
@@ -120,7 +120,7 @@
         background-color: #49996f;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menuitem.menuitem--active {
             background-color: #eee;
             border-right: 3px solid #4db788;
@@ -144,7 +144,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menuitem-icon {
             margin: 0 15px;
             height: 30px;
@@ -176,7 +176,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .menuitem-label {
             color: #49996f;
             flex: 1 1 0;
@@ -212,7 +212,7 @@
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .sub-menubar {
             background-color: transparent;
             position: static;
@@ -237,7 +237,7 @@
         text-decoration: none;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .sub-menuitem {
             border: none;
             color: #777;

--- a/src/components/RankedPlayer.vue
+++ b/src/components/RankedPlayer.vue
@@ -7,8 +7,11 @@
                 <img class="avatar" :src="rankedPlayer.user.avatarUrl">
             </div>
         </div>
-        <div class="nameDetails">
-            <div class="name">{{ rankedPlayer.user.name }}</div>
+        <div class="namesAndDetails">
+            <div class="names">
+                <div class="name">{{ rankedPlayer.user.name }}</div>
+                <div class="anonymousName">{{ rankedPlayer.user.anonymousName }}</div>
+            </div>
             <div class="details">
                 <div class="scorePronos">
                     <span class="score"><strong>{{ rankedPlayer.stats.totalScore }}</strong>{{ rankedPlayer.stats.totalScore | frenchPlural 'pt' }}</span>
@@ -81,7 +84,7 @@
         .ranking {
             margin-bottom: 0;
             text-align: right;
-            width: 80px;
+            width: 70px;
         }
     }
 
@@ -106,14 +109,27 @@
         width: 100%;
     }
 
-    .nameDetails {
+    .namesAndDetails{
         overflow: hidden;
     }
 
     @media (min-width: 700px) {
-        .nameDetails {
+        .namesAndDetails{
             display: flex;
             flex: 1 1 0;
+        }
+    }
+
+    .names {
+        margin-bottom: 5px;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+    @media (min-width: 700px) {
+        .names {
+            flex: 1 1 0;
+            margin-bottom: 0;
         }
     }
 
@@ -121,19 +137,24 @@
         color: #333;
         font-size: 16px;
         font-weight: bold;
-        margin-bottom: 5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .anonymousName {
+        color: #777;
+        font-size: 14px;
+        font-style: italic;
+        font-weight: normal;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
     }
 
     @media (min-width: 700px) {
-        .name {
-            flex: 1 1 0;
+        .anonymousName {
             margin-bottom: 0;
-            overflow: visible;
-            text-overflow: ellipsis;
-            white-space: normal;
         }
     }
 

--- a/src/components/TitleBar.vue
+++ b/src/components/TitleBar.vue
@@ -65,13 +65,13 @@
         width: 30px;
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .icon {
             display: block;
         }
     }
 
-    @media (min-width: 850px) {
+    @media (min-width: 900px) {
         .huit {
             display: none;
         }


### PR DESCRIPTION
A merger après https://github.com/huitparfait/huitparfait-api/pull/30 (modification de l'API)
J'ai passé le breakpoint de 850px à 900px pour plus de lisibilité dans le cas d'une largeur de 850px, les noms du classement sont vraiment écrasés même dans l'ancienne version, et avec cette feature ils n'ont même plus la possibilité de passer à la ligne (ils sont en ellipsis)